### PR TITLE
Fix copy-paste from and to switch

### DIFF
--- a/plugin/pasta.vim
+++ b/plugin/pasta.vim
@@ -10,6 +10,7 @@ let g:loaded_pasta = 1
 function! s:NormalPasta(p, o)
   if (getregtype() ==# "V")
     exe "normal! " . a:o . "\<space>\<bs>\<esc>" . v:count1 . '"' . v:register . ']p'
+	 exe "normal! =`]"
     " Save the `[ and `] marks (point to the last modification)
     let first = getpos("'[")
     let last  = getpos("']")
@@ -21,6 +22,7 @@ function! s:NormalPasta(p, o)
     call setpos("']", last)
   else
     exe "normal! " . v:count1 . '"' . v:register . a:p
+	 exe "normal! =`]"
   endif
 endfunction
 


### PR DESCRIPTION
If we copy two lines with case and past - it will not be formatted well:
![image](https://cloud.githubusercontent.com/assets/3524663/14783781/a6183100-0afa-11e6-82c3-b1c60081f17d.png)
