### PR TITLE
Disable pasta.vim for ctrl-p buffers

### DIFF
--- a/plugin/pasta.vim
+++ b/plugin/pasta.vim
@@ -58,7 +58,7 @@ endfunction
 
 if !exists("g:pasta_disabled_filetypes")
   let g:pasta_disabled_filetypes = ["python", "coffee", "markdown",
-        \"yaml", "slim", "nerdtree", "netrw", "startify"]
+        \"yaml", "slim", "nerdtree", "netrw", "startify", "ctrlp"]
 endif
 
 if !exists("g:pasta_paste_before_mapping")


### PR DESCRIPTION
Disabling vim-pasta in ctrl-p buffers to avoid conflicts when typing 'p'.

<img width="504" alt="screen shot 2018-07-12 at 12 50 44" src="https://user-images.githubusercontent.com/4930052/42610013-cd46331c-85d2-11e8-958d-a11211c668e4.png">

Following the same approach as https://github.com/sickill/vim-pasta/issues/9

Sorry not opening an issue first, but as I had solved for me I thought it would be easier to open a PR. 
Feel free to close this PR if you think this is not the way to go.
@sickill